### PR TITLE
fix: update package.json to include peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
         "eslint-config-plus": "^2.0.2",
         "eslint-plugin-html": "^8.1.1",
         "jest": "^29.7.0"
+    },
+    "peerDependencies": {
+        "@jest/reporters": "*"
     }
 }


### PR DESCRIPTION
When running with `pnpm` this package will fail to find `@jest/reporters`. This fix enables the dependency resolver to properly know that this package needs this dependency to exist.